### PR TITLE
updating memcached installation for php 5.6

### DIFF
--- a/infrastructure/environments/development/docker/containers/d7/php/Dockerfile
+++ b/infrastructure/environments/development/docker/containers/d7/php/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y \
         libmcrypt-dev \
         libpng12-dev \
     && rm -r /var/lib/apt/lists/* \
-    && pecl install memcached \
+    && pecl install memcached-2.2.0 \
     && docker-php-ext-install -j$(nproc) mbstring \
     && docker-php-ext-install -j$(nproc) pdo_mysql \
     && docker-php-ext-install -j$(nproc) zip \

--- a/infrastructure/environments/development/docker/containers/d7/ssh/Dockerfile
+++ b/infrastructure/environments/development/docker/containers/d7/ssh/Dockerfile
@@ -22,8 +22,6 @@ RUN sed -i 's/PermitRootLogin without-password/PermitRootLogin yes/' /etc/ssh/ss
 RUN mkdir /var/run/sshd
 RUN chmod 0755 /var/run/sshd
 
-RUN curl https://drupalconsole.com/installer -L -o drupal.phar && mv drupal.phar /usr/local/bin/drupal && chmod +x /usr/local/bin/drupal && drupal init --override
-
 EXPOSE 22
 WORKDIR /var/www/public_html
 CMD ["/usr/sbin/sshd", "-D"]


### PR DESCRIPTION
J,

Veja o último comentário aqui: https://github.com/docker-library/php/issues/132

Precisa atualizar o comando de install do memcached para permitir a sua instalação com php 5.6 